### PR TITLE
Expanded Pi-hole container and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,50 @@
 # balena-pihole
 
-[balena.io](https://www.balena.io/) stack with the following services:
-* [pihole](https://hub.docker.com/r/pihole/pihole/)
-* [unbound](https://hub.docker.com/r/klutchell/unbound/)
+If you're looking for a way to quickly and easily get up and running with a Pi-hole device for your home network, this is the project for you.
+
+This project is a [balenaCloud](https://www.balena.io/cloud) stack with the following services:
+* [Pi-hole](https://hub.docker.com/r/pihole/pihole/) (including [PADD](https://github.com/jpmck/PADD))
+* [Unbound](https://hub.docker.com/r/klutchell/unbound/)
+
+balenaCloud is a free service to remotely manage and update your Raspberry Pi through an online dashboard interface, as well as providing remote access to the Pi-hole web interface without any additional configuation.
+
 
 ## Getting Started
+
+To get started you'll first need to sign up for a free balenaCloud account and flash your device.
 
 https://www.balena.io/docs/learn/getting-started
 
 ## Deployment
 
-### Application Environment Variables
+Once your account is set up, deployment is carried out by downloading the project and pushing it to your device either via Git or the balena CLI.
 
-|Name|Value|
-|---|---|
-|`TZ`|`America/Toronto`|
+### Application Environment Variables
+Application envionment variables apply to all services within the application, and can be applied fleet-wide to apply to multiple devices.
+
+|Name|Value|Purpose|
+|---|---|---|
+|`TZ`|E.g. `America/Toronto`, find a [list of all timezone values here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).|To inform both `pihole` and `unbound` services of the timezone in your location, in order to set times and dates within the applications correctly.|
 
 ### Service Variables
+Service variables are set to apply only to a specific service within the application, but can also be set to apply to all devices in the fleet.
 
-|Service|Name|Value|
-|---|---|---|
-|`pihole`|`DNS1`|`127.0.0.1#1053`|
-|`pihole`|`DNS2`|`127.0.0.1#1053`|
-|`pihole`|`DNSMASQ_LISTENING`|`eth0`|
-|`pihole`|`INTERFACE`|`eth0`|
-|`pihole`|`IPv6`|`False`|
-|`pihole`|`ServerIP`|_[external device ip]_|
-|`pihole`|`WEBPASSWORD`|_(optional)_|
+|Service|Name|Value|Purpose|
+|---|---|---|---|
+|`pihole`|`DNS1`|`127.0.0.1#1053`|To tell Pi-hole where to forward DNS requests that aren’t blocked. We’re using the Unbound project here but you can specify your own.|
+|`pihole`|`DNS2`|`127.0.0.1#1053`|Secondary DNS server - see above.|
+|`pihole`|`DNSMASQ_LISTENING`|`eth0`|We set this to eth0 to indicate we want DNSMASQ to listen on the ethernet interface of the Raspberry Pi|
+|`pihole`|`INTERFACE`|`eth0`|As above|
+|`pihole`|`IPv6`|`False`|We’re not using IPv6 internally here.|
+|`pihole`|`ServerIP`|_[external device ip]_|Set this to the local IP address of your Pi-hole device to enable full ad-blocking. [Blocking modes are explained here](https://docs.pi-hole.net/ftldns/blockingmode/). `0.0.0.0` provides unspecified IP blocking.
+|`pihole`|`WEBPASSWORD`|`mysecretpassword`|__Optional__ password for accessing the web-based interface of Pi-hole - you won’t be able to access the admin panel without defining a password here.
 
 ## Usage
 
 https://docs.pi-hole.net/guides/unbound/
+
+## Help
+If you're having trouble getting the project running, submit an issue or post on the forums at https://forums.balena.io.
 
 ## Author
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,8 @@ services:
 
   # https://hub.docker.com/r/pihole/pihole/
   pihole:
-    image: pihole/pihole:4.1.1_armhf
+    build: ./pihole
+    privileged: true
     volumes:
       - 'pihole_config:/etc/pihole'
       - 'dnsmasq_config:/etc/dnsmasq.d'

--- a/pihole/Dockerfile
+++ b/pihole/Dockerfile
@@ -1,0 +1,29 @@
+FROM balenalib/raspberrypi3-debian:latest-build AS build
+
+RUN mkdir -p /usr/src
+WORKDIR /usr/src
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  cmake \
+  libraspberrypi-dev
+
+RUN wget https://raw.githubusercontent.com/tasanakorn/rpi-fbcp/master/CMakeLists.txt
+RUN wget https://raw.githubusercontent.com/tasanakorn/rpi-fbcp/master/main.c
+
+RUN mkdir build
+WORKDIR /usr/src/build
+RUN cmake ..
+RUN make
+
+FROM pihole/pihole:4.1.1_armhf
+
+RUN mkdir -p /usr/src
+WORKDIR /usr/src
+
+COPY --from=build /opt/vc/lib/* /opt/vc/lib/
+COPY --from=build /usr/src/build/fbcp /usr/src/
+COPY services/ /etc/services.d/
+
+RUN sed -i '/$AUTHORIZED_HOSTNAMES = array(/ a "balena-devices.com",' /var/www/html/admin/scripts/pi-hole/php/auth.php
+RUN wget https://raw.githubusercontent.com/jpmck/PADD/master/padd.sh
+RUN chmod +x padd.sh

--- a/pihole/services/fbcp/finish
+++ b/pihole/services/fbcp/finish
@@ -1,0 +1,4 @@
+#!/usr/bin/with-contenv bash
+
+s6-echo "Stopping fbcp"
+killall -9 fbcp

--- a/pihole/services/fbcp/run
+++ b/pihole/services/fbcp/run
@@ -1,0 +1,4 @@
+#!/usr/bin/with-contenv bash
+
+s6-echo "Starting fbcp"
+/usr/src/fbcp

--- a/pihole/services/padd/finish
+++ b/pihole/services/padd/finish
@@ -1,0 +1,4 @@
+#!/usr/bin/with-contenv bash
+
+s6-echo "Stopping PADD"
+killall -9 padd.sh

--- a/pihole/services/padd/run
+++ b/pihole/services/padd/run
@@ -1,0 +1,4 @@
+#!/usr/bin/with-contenv bash
+
+s6-echo "Starting PADD"
+/usr/src/padd.sh 2> /dev/null > /dev/tty1


### PR DESCRIPTION
Expanded the Pi-hole container to include fbcp and PADD for use with a Pi-TFT screen. Added additional information to README.