### PR TITLE
Install bc (required by PADD)

### DIFF
--- a/pihole/Dockerfile
+++ b/pihole/Dockerfile
@@ -2,7 +2,7 @@ FROM balenalib/raspberrypi3-debian:latest-build AS build
 
 WORKDIR /usr/src
 
-RUN install_packages cmake libraspberrypi-dev
+RUN install_packages cmake libraspberrypi-dev bc
 
 RUN curl -sSL https://raw.githubusercontent.com/tasanakorn/rpi-fbcp/master/CMakeLists.txt -O
 RUN curl -sSL https://raw.githubusercontent.com/tasanakorn/rpi-fbcp/master/main.c -O
@@ -17,6 +17,7 @@ WORKDIR /usr/src
 
 COPY --from=build /opt/vc/lib/* /opt/vc/lib/
 COPY --from=build /usr/src/build/fbcp /usr/src/
+COPY --from=build /usr/bin/bc /usr/bin/bc
 COPY services/ /etc/services.d/
 
 RUN sed -i '/$AUTHORIZED_HOSTNAMES = array(/ a "balena-devices.com",' /var/www/html/admin/scripts/pi-hole/php/auth.php


### PR DESCRIPTION
bc was removed as a Pi-hole dependency in the latest version but is required by PADD.