### PR TITLE
Use Jessie for compiling FBCP otherwise it doesn't produce output

### DIFF
--- a/pihole/Dockerfile
+++ b/pihole/Dockerfile
@@ -1,4 +1,4 @@
-FROM balenalib/raspberrypi3-debian:stretch-build AS build
+FROM balenalib/raspberrypi3-debian:jessie-build AS build
 
 WORKDIR /usr/src
 


### PR DESCRIPTION
I did further testing and found that although FBCP compiles with Stretch the binary doesn't work within the Pi-hole image. Changed to compiling it on Jessie and everything works as it should.

Change-type: patch
Signed-off-by: Chris Crocker-White <chriscw@balena.io>