### PR TITLE
fbcp: use balenablocks/fbcp:1.0.0 with dtoverlay support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,7 @@ the `FBCP_DISPLAY` variable within the dashboard. This variable should be set to
 - `waveshare-st7789vw-hat`
 - `waveshare-st7735s-hat`
 - `kedei-v63-mpi3501`
-
-If your display is not listed above, please check if the [fbcp-ili9341](https://github.com/juj/fbcp-ili9341)
-driver that `fbcp` block uses supports it.
-PRs are welcomed to add support for further displays in the [fbcp block](https://github.com/balenablocks/fbcp).
-
-If you had previously enabled your screen via `BALENA_HOST_CONFIG_dtoverlay`
-in your device config you will need to remove/disable that setting.
-
-If your screen doesn't work with any of the new `FBCP_DISPLAY` display options, the old
-display block using DT overlays is still available in the `fpi-fbcp` branch!
+- `dtoverlay` (requires `BALENA_HOST_CONFIG_dtoverlay` to be set)
 
 #### Configuring HDMI and TFT display sizes
 

--- a/dbus/Dockerfile
+++ b/dbus/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:3.13.0
+
+WORKDIR /usr/src/app
+
+# hadolint ignore=DL3018
+RUN apk add --no-cache dbus
+
+ENV DBUS_SYSTEM_BUS_ADDRESS 'unix:path=/host/run/dbus/system_bus_socket'
+
+COPY init.sh .
+
+RUN chmod +x ./init.sh
+
+CMD [ "./init.sh" ]

--- a/dbus/init.sh
+++ b/dbus/init.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# prevent plymouth from blocking fbcp
+# https://github.com/klutchell/balena-pihole/issues/25
+# https://github.com/balena-os/meta-balena/issues/1772
+dbus-send \
+    --system \
+    --dest=org.freedesktop.systemd1 \
+    --type=method_call \
+    --print-reply \
+    /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.StartUnit \
+    string:"plymouth-quit.service" string:"replace"
+
+exit 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,3 +29,12 @@ services:
   fbcp:
     image: balenablocks/fbcp:1.0.0
     privileged: true
+
+  # prevent plymouth from blocking fbcp
+  # https://github.com/klutchell/balena-pihole/issues/25
+  # https://github.com/balena-os/meta-balena/issues/1772
+  dbus:
+    build: dbus
+    restart: on-failure
+    labels:
+        io.balena.features.dbus: "1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,5 @@ services:
 
   # https://github.com/balenablocks/fbcp
   fbcp:
-    image: balenablocks/fbcp
+    image: balenablocks/fbcp:1.0.0
     privileged: true
-    # restart: on-failure
-    # labels:
-    #     io.balena.features.dbus: "1"


### PR DESCRIPTION
Note that `dtoverlay` is a new label and `FBCP_DISPLAY` option that relies on `BALENA_HOST_CONFIG_dtoverlay` being set in order to use the legacy rpi-fbcp driver (supports more displays via kernel device trees).

balenablocks PR is here: https://github.com/balenablocks/fbcp/pull/5

Change-type: minor
Connects-to: https://github.com/klutchell/balena-pihole/issues/64
Signed-off-by: Kyle Harding <kyle@balena.io>