### PR TITLE
Update environment variables and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,8 @@ Device Variables apply to all services within the application, and can be applie
 | `DNSMASQ_LISTENING` | `eth0`             | We set this to `eth0` to indicate we want DNSMASQ to listen on the ethernet interface of the Raspberry Pi. If you're connecting to your network with WiFi replace this with `wlan0`                                              |
 | `INTERFACE`         | `eth0`             | As above.                                                                                                                                                                                                                        |
 | `WEBPASSWORD`       | `mysecretpassword` | _(optional)_ password for accessing the web-based interface of Pi-hole - you won’t be able to access the admin panel without defining a password here.                                                                           |
-| `DNS1`              | `127.0.0.1#5053`   | _(optional)_ Tell Pi-hole where to forward DNS requests that aren’t blocked. We’re using the [Unbound](https://unbound.net) project here but you can specify your own.                                                           |
-| `DNS2`              | `127.0.0.1#5053`   | _(optional)_ Secondary DNS server - see above.                                                                                                                                                                                   |
-| `ServerIP`          | `x.x.x.x`          | _(recommended)_ Set to your server's LAN IP, used by web block modes and lighttpd bind address.                                                                                                                                  |
+| `PIHOLE_DNS_`              | `127.0.0.1#5053;8.8.8.8;8.8.4.4`   | _(optional)_ Tell Pi-hole where to forward DNS requests that aren’t blocked. We’re using the [Unbound](https://unbound.net) project here but you can specify your own using IPs delimited by semi-colons (see example).                                                        |
+| `ServerIP`          | `x.x.x.x`          | Set to your server's LAN IP, used by web block modes and lighttpd bind address.  Mandatory with this implementation of Pi-hole.                                                                                                                                |
 
 ## Usage
 

--- a/balena.yml
+++ b/balena.yml
@@ -17,8 +17,7 @@ data:
     - DNSMASQ_LISTENING: 'eth0'
     - INTERFACE: 'eth0'
     - WEBPASSWORD: 'mysecretpassword'
-    - DNS1: '127.0.0.1#5053'
-    - DNS2: '127.0.0.1#5053'
+    - PIHOLE_DNS_: '127.0.0.1#5053'
     - FBCP_DISPLAY: ""
   defaultDeviceType: "raspberrypi3"
   supportedDeviceTypes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,7 @@ services:
     environment:
       DNSMASQ_LISTENING: eth0
       INTERFACE: eth0
-      DNS1: 127.0.0.1#5053
-      DNS2: 127.0.0.1#5053
+      PIHOLE_DNS_: 127.0.0.1#5053
     network_mode: host
     depends_on:
       - unbound


### PR DESCRIPTION
Added `PIHOLE_DNS_` to docs and YAML files to replace deprecated `DNS1`/`DNS2` syntax.  