### PR TITLE
Add Plex as private-domain to allow DNS rebinding

### DIFF
--- a/unbound/unbound.conf
+++ b/unbound/unbound.conf
@@ -83,6 +83,9 @@ server:
     private-address: fd00::/8
     private-address: fe80::/10
 
+        # Some common domains that require DNS rebinding to work correctly
+    private-domain: plex.direct
+
 	# File with trust anchor for one zone, which is tracked with RFC5011 probes.
 	# The probes are several times per month, thus the machine must be online frequently.
 	# The initial file can be one with contents as described in trust-anchor-file.


### PR DESCRIPTION
Plex requires DNS rebinding in order to provide secure connectivity to some devices on a LAN.  Unbound DNS Binding Protection breaks this.  Adding `plex.direct` as a private domain to work around this.  