### PR TITLE
Upgrade to Pi-hole v5.8 and FTL v5.8.1

### DIFF
--- a/pihole/Dockerfile
+++ b/pihole/Dockerfile
@@ -1,4 +1,4 @@
-FROM pihole/pihole:v5.7
+FROM pihole/pihole:v5.8.1
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Upgrade to v5.8.1 - https://github.com/pi-hole/docker-pi-hole/releases/tag/v5.8.1

Hold until April 28.