### PR TITLE
Set the fleet semver to the Pi-hole version

### DIFF
--- a/balena.yml
+++ b/balena.yml
@@ -1,6 +1,6 @@
 name: "Pi-hole"
 type: "sw.application"
-version: 1.0.0
+version: 5.8.1
 description: "Pi-hole is a Linux network-level advertisement and Internet tracker blocking application!"
 fleetcta: Block dem ads
 post-provisioning: >-


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>

Pushing a new release to an existing fleet will automatically increment the `-rev` suffix.

![image](https://user-images.githubusercontent.com/20458272/131707007-72e052f0-bda0-4a71-9ef6-1e882121cbcd.png)
