### PR TITLE
Move PADD to a separate service container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,21 +7,27 @@ volumes:
 services:
   # https://hub.docker.com/r/pihole/pihole
   pihole:
-    build: ./pihole
+    build: pihole
     privileged: true
+    network_mode: host
     volumes:
       - "pihole_config:/etc/pihole"
       - "dnsmasq_config:/etc/dnsmasq.d"
     dns:
       - "127.0.0.1"
       - "1.1.1.1"
+
+  # https://github.com/pi-hole/PADD
+  padd:
+    build: padd
+    privileged: true
     network_mode: host
     labels:
       io.balena.features.dbus: "1"
 
   # https://github.com/klutchell/unbound-dnscrypt
   unbound:
-    build: ./unbound
+    build: unbound
     privileged: true
     ports:
       - "5053:5053/tcp"

--- a/padd/Dockerfile
+++ b/padd/Dockerfile
@@ -1,0 +1,23 @@
+FROM debian:bullseye-20210902-slim
+
+WORKDIR /usr/src/app
+
+# hadolint ignore=DL3008
+RUN export DEBIAN_FRONTEND=noninteractive && \
+	apt-get update && \
+	apt-get install --no-install-recommends -y ca-certificates console-setup curl kmod dbus && \
+	apt-get clean && rm -rf /var/lib/apt/lists/*
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN curl -fsSL https://github.com/pi-hole/PADD/archive/v3.6.2.tar.gz | tar xz --strip-components 1 \
+	&& chmod +x padd.sh
+
+ENV FTLPORT 4711
+ENV DBUS_SYSTEM_BUS_ADDRESS 'unix:path=/host/run/dbus/system_bus_socket'
+
+COPY run.sh ./
+
+RUN chmod +x ./run.sh
+
+CMD [ "/usr/src/app/run.sh" ]

--- a/padd/run.sh
+++ b/padd/run.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/with-contenv bash
-# shellcheck shell=bash
+#!/usr/bin/env bash
 
-s6-echo "Stopping plymouth service"
+echo "Stopping plymouth service..."
+
 # prevent plymouth from blocking fbcp
 # https://github.com/klutchell/balena-pihole/issues/25
 # https://github.com/balena-os/meta-balena/issues/1772
@@ -13,14 +13,16 @@ dbus-send \
     /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.StartUnit \
     string:"plymouth-quit.service" string:"replace"
 
-s6-echo "Starting PADD"
+echo "Configuring console..."
 
 # fix for PADD fonts
 sed -i "s/^FONTFACE.*/FONTFACE=\"${FONTFACE}\"/" /etc/default/console-setup
 sed -i "s/^FONTSIZE.*/FONTSIZE=\"${FONTSIZE}\"/" /etc/default/console-setup
 dpkg-reconfigure console-setup 2> /dev/null > /dev/tty1
 
-# wait for pihole api to become available
-sleep 20
+# TODO: wait for /dev/tcp/127.0.0.1/$FTLPORT to become available
+# https://github.com/pi-hole/PADD/blob/master/padd.sh#L124
+
+echo "Starting PADD..."
 
 /usr/src/app/padd.sh 2> /dev/null > /dev/tty1

--- a/pihole/Dockerfile
+++ b/pihole/Dockerfile
@@ -1,16 +1,6 @@
 FROM pihole/pihole:2021.09
 
-WORKDIR /usr/src/app
-
 COPY cont-init.d/ /etc/cont-init.d/
-COPY services/ /etc/services.d/
-
-ENV DEBIAN_FRONTEND noninteractive
-
-# hadolint ignore=DL3008
-RUN apt-get update && \
-	apt-get install --no-install-recommends -y console-setup kmod dbus && \
-	apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # hadolint ignore=SC2016
 RUN sed '/$AUTHORIZED_HOSTNAMES = array(/ a "balena-devices.com",' -i /var/www/html/admin/scripts/pi-hole/php/auth.php
@@ -20,15 +10,10 @@ RUN sed '/$AUTHORIZED_HOSTNAMES = array(/ a "balena-devices.com",' -i /var/www/h
 # otherwise dnsmasq will fail to start since balena is using 53 on some interfaces
 RUN echo "bind-interfaces" >> /etc/dnsmasq.conf
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl -fsSL https://github.com/pi-hole/PADD/archive/v3.6.2.tar.gz | tar xz --strip-components 1 \
-	&& chmod +x padd.sh
-
 ENV INTERFACE eth0
 ENV DNSMASQ_LISTENING single
 ENV PIHOLE_DNS_ 1.1.1.1;1.0.0.1
 ENV FONTFACE Terminus
 ENV FONTSIZE 8x14
 ENV WEBPASSWORD balena
-
-ENV DBUS_SYSTEM_BUS_ADDRESS 'unix:path=/host/run/dbus/system_bus_socket'
+ENV FTLPORT 4711

--- a/pihole/services/padd/finish
+++ b/pihole/services/padd/finish
@@ -1,5 +1,0 @@
-#!/usr/bin/with-contenv bash
-# shellcheck shell=bash
-
-s6-echo "Stopping PADD"
-killall -9 padd.sh


### PR DESCRIPTION
This reduces the changes we have to make to the official Pi-hole
Docker container and aligns with the ethos of each container running
a single service.

Resolves: https://github.com/klutchell/balena-pihole/issues/89
Change-type: major
Signed-off-by: Kyle Harding <kyle@balena.io>