### PR TITLE
Update Pi-hole to release 2021.12.1

### DIFF
--- a/balena.yml
+++ b/balena.yml
@@ -1,6 +1,6 @@
 name: "Pi-hole"
 type: "sw.application"
-version: 2021.11.0
+version: 2021.12.1
 description: "Pi-hole is a Linux network-level advertisement and Internet tracker blocking application!"
 post-provisioning: >-
   ## Usage instructions

--- a/pihole/Dockerfile
+++ b/pihole/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/r/pihole/pihole/tags
-FROM pihole/pihole:2021.11
+FROM pihole/pihole:2021.12.1
 
 WORKDIR /usr/src/app
 

--- a/pihole/Dockerfile
+++ b/pihole/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # hadolint ignore=DL3008
 RUN apt-get update && \
-	apt-get install --no-install-recommends -y console-setup kmod dbus && \
+	apt-get install --no-install-recommends -y console-setup kmod dbus netcat && \
 	apt-get clean && rm -rf /var/lib/apt/lists/*
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
Update Pi-hole to release 2021.12.1
https://github.com/pi-hole/docker-pi-hole/releases/tag/2021.12
https://github.com/pi-hole/docker-pi-hole/releases/tag/2021.12.1

Signed-off-by: Roddie Hasan roddie@krweb.net