### PR TITLE
Update Pi-hole to release 2022.01.1

### DIFF
--- a/.github/workflows/balena.yml
+++ b/.github/workflows/balena.yml
@@ -7,18 +7,21 @@ on:
       - main
 
 jobs:
-  build:
+  deploy:
     if: github.actor == github.repository_owner
     runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: true
+      matrix:
+        fleet: [gh_klutchell/pi-hole]
 
     steps:
       - uses: actions/checkout@v2
-
-      - uses: balena-io/balena-ci@v0.4.5
+      - uses: balena-io/deploy-to-balena-action@v0.5.1
         with:
           balena_token: ${{ secrets.BALENA_API_KEY }}
-          fleet: ${{ secrets.BALENA_FLEET_SLUG }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          versionbot: false
           environment: balena-cloud.com
-          create_ref: true
+          fleet: ${{ matrix.fleet }}
+          versionbot: false
+          create_tag: true

--- a/balena.yml
+++ b/balena.yml
@@ -1,6 +1,6 @@
 name: "Pi-hole"
 type: "sw.application"
-version: 2021.11.0
+version: 2022.01.1
 description: "Pi-hole is a Linux network-level advertisement and Internet tracker blocking application!"
 post-provisioning: >-
   ## Usage instructions

--- a/pihole/Dockerfile
+++ b/pihole/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/r/pihole/pihole/tags
-FROM pihole/pihole:2021.11
+FROM pihole/pihole:2022.01.1
 
 WORKDIR /usr/src/app
 

--- a/pihole/Dockerfile
+++ b/pihole/Dockerfile
@@ -15,8 +15,9 @@ RUN apt-get update && \
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ARG PADD_VERSION=3.6.2
-ARG PADD_SHA256=7e1fcfefc5c24bd032b31ed79afceda21019faeb88535cdf15ba558b90141c01
+# https://github.com/pi-hole/PADD/releases
+ARG PADD_VERSION=3.6.3
+ARG PADD_SHA256=00894999c83608731aad9a337858ec010a0f5acd47840fb656c3b45867372419
 
 RUN curl -fsSL https://github.com/pi-hole/PADD/archive/v${PADD_VERSION}.tar.gz -o padd.tar.gz && \
 	echo "${PADD_SHA256}  padd.tar.gz" | sha256sum -c - && \

--- a/pihole/Dockerfile
+++ b/pihole/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # hadolint ignore=DL3008
 RUN apt-get update && \
-	apt-get install --no-install-recommends -y console-setup kmod dbus && \
+	apt-get install --no-install-recommends -y console-setup kmod dbus netcat && \
 	apt-get clean && rm -rf /var/lib/apt/lists/*
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
https://github.com/pi-hole/docker-pi-hole/releases/tag/2022.01.1

Signed-off-by: Kyle Harding <kyle@balena.io>