### PR TITLE
Update Pi-hole to release 2022.02.1

### DIFF
--- a/balena.yml
+++ b/balena.yml
@@ -1,6 +1,6 @@
 name: "Pi-hole"
 type: "sw.application"
-version: 2022.1.1
+version: 2022.2.1
 description: "Pi-hole is a Linux network-level advertisement and Internet tracker blocking application!"
 post-provisioning: >-
   ## Usage instructions

--- a/pihole/Dockerfile
+++ b/pihole/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/r/pihole/pihole/tags
-FROM pihole/pihole:2022.01.1
+FROM pihole/pihole:2022.02.1
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
https://github.com/pi-hole/docker-pi-hole/releases/tag/2022.02
https://github.com/pi-hole/docker-pi-hole/releases/tag/2022.02.1

Signed-off-by: Roddie Hasan <roddie@krweb.net>