### PR TITLE
Allow any user to run the balena deploy action

### DIFF
--- a/.github/workflows/balena.yml
+++ b/.github/workflows/balena.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   deploy:
-    if: github.actor == github.repository_owner
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: true


### PR DESCRIPTION
Expect it to fail for external users and forks.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>