### PR TITLE
Remove custom wait for FTL port before starting PADD

### DIFF
--- a/pihole/services/padd/run
+++ b/pihole/services/padd/run
@@ -16,12 +16,5 @@ sed -i "s/^FONTFACE.*/FONTFACE=\"${FONTFACE}\"/" /etc/default/console-setup
 sed -i "s/^FONTSIZE.*/FONTSIZE=\"${FONTSIZE}\"/" /etc/default/console-setup
 dpkg-reconfigure console-setup 2> /dev/null > /dev/tty1
 
-# wait for FTL port to become available
-while ! nc -z 127.0.0.1 "$(</run/pihole-FTL.port)"
-do
-    s6-echo "Waiting for FTL on port $(</run/pihole-FTL.port)..."
-    sleep 5
-done
-
 s6-echo "Starting PADD..."
 /usr/src/app/padd.sh 2> /dev/null > /dev/tty1


### PR DESCRIPTION
By now PADD should be able to handle situations where the FTL port is not yet listening, and retry or wait.

The file where the FTL port was being written has also been removed: https://github.com/pi-hole/FTL/pull/1445/commits/597e98e7731eb5ff3b7b61a54057a10be47c8d6f

Signed-off-by: Kyle Harding <kyle@balena.io>
See: https://github.com/pi-hole/FTL/pull/1445
See: https://github.com/klutchell/balena-pihole/pull/96