### PR TITLE
Bind to all interfaces by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ Device Variables apply to all services within the application, and can be applie
 | Name           | Default           | Purpose                                                                                                                                                            |
 | -------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `TZ`           | `UTC`             | The timezone in your location. Find a [list of all timezone values here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).                            |
-| `INTERFACE`    | `eth0`            | Provide the name of your device's primary network interface, usually `eth0` for wired or `wlan0` for wireless.                                                     |
 | `WEBPASSWORD`  | `balena`          | Password for accessing the web-based interface of Pi-hole - you won’t be able to access the admin panel without defining a password here.                          |
 | `PIHOLE_DNS_`  | `1.1.1.1;1.0.0.1` | Tell Pi-hole where to forward DNS requests that aren’t blocked. We’re using Cloudflare by default but you can specify your own using IPs delimited by semi-colons. |
 | `SET_HOSTNAME` | `pihole`          | Set a custom device hostname on application start.                                                                                                                 |
+
+Additional supported environment variables can be found [here](https://github.com/pi-hole/docker-pi-hole#environment-variables).
 
 ## Usage
 

--- a/balena.yml
+++ b/balena.yml
@@ -25,7 +25,6 @@ data:
   applicationConfigVariables:
     - BALENA_HOST_CONFIG_gpu_mem: 64
   applicationEnvironmentVariables:
-    - INTERFACE: 'eth0'
     - WEBPASSWORD: 'balena'
     - PIHOLE_DNS_: '1.1.1.1;1.0.0.1'
     - FBCP_DISPLAY: ""

--- a/pihole/Dockerfile
+++ b/pihole/Dockerfile
@@ -1,11 +1,6 @@
 # https://hub.docker.com/r/pihole/pihole/tags
 FROM pihole/pihole:2023.01.10
 
-# https://serverfault.com/a/817791
-# force dnsmasq to bind only the interfaces it is listening on
-# otherwise dnsmasq will fail to start since balena is using 53 on some interfaces
-RUN echo "bind-interfaces" > /etc/dnsmasq.d/balena.conf
-
 ENV DEBIAN_FRONTEND noninteractive
 
 # hadolint ignore=DL3008
@@ -18,8 +13,7 @@ COPY s6-overlay/ /etc/s6-overlay/
 
 RUN chmod +x /etc/cont-init.d/10-custom.sh
 
-ENV INTERFACE eth0
-ENV DNSMASQ_LISTENING single
+ENV DNSMASQ_LISTENING all
 ENV PIHOLE_DNS_ 1.1.1.1;1.0.0.1
 ENV FONTFACE Terminus
 ENV FONTSIZE 8x14


### PR DESCRIPTION
Exclude resin-dns from port bindings to avoid conflicts.

Signed-off-by: Kyle Harding <kyle@balena.io>