### PR TITLE
Exclude tailscale0 and resin-vpn from dnsmasq interfaces

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,6 @@ services:
     volumes:
       - "pihole_config:/etc/pihole"
       - "dnsmasq_config:/etc/dnsmasq.d"
-    dns:
-      - "127.0.0.1"
-      - "1.1.1.1"
     network_mode: host
     labels:
       io.balena.features.dbus: "1"

--- a/pihole/cont-init.d/10-custom.sh
+++ b/pihole/cont-init.d/10-custom.sh
@@ -6,8 +6,12 @@ set -e
 # avoid port conflicts with resin-dns
 # https://docs.pi-hole.net/ftldns/interfaces/
 # these steps must be at runtime because /etc/dnsmasq.d is a user volume
-echo "bind-interfaces" > /etc/dnsmasq.d/90-resin-dns.conf
-echo "except-interface=resin-dns" >> /etc/dnsmasq.d/90-resin-dns.conf
+{
+   echo "bind-interfaces" ;
+   echo "except-interface=resin-dns" ;
+   echo "except-interface=resin-vpn" ;
+   echo "except-interface=tailscale0" ;
+} > /etc/dnsmasq.d/90-resin-dns.conf
 
 if [ -f /etc/dnsmasq.d/balena.conf ]
 then


### PR DESCRIPTION
Change-type: patch

This PR is meant to avoid a state where pihole is running and tailscale is connected but devices on the tailscale network are unable to resolve any hosts.