### PR TITLE
Bind web dashboard to all interfaces by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,13 @@ services:
       - /dev/tty1
     tmpfs:
       - /var/log/pihole
+    environment:
+      DNSMASQ_LISTENING: all
+      PIHOLE_DNS_: 1.1.1.1;1.0.0.1
+      FONTFACE: Terminus
+      FONTSIZE: 8x14
+      WEBPASSWORD: balena
+      VIRTUAL_HOST: balena-devices.com
 
   unbound:
     build: unbound

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       FONTSIZE: 8x14
       WEBPASSWORD: balena
       VIRTUAL_HOST: balena-devices.com
+      WEB_BIND_ADDR: 0.0.0.0
 
   unbound:
     build: unbound

--- a/pihole/Dockerfile
+++ b/pihole/Dockerfile
@@ -13,11 +13,4 @@ COPY s6-overlay/ /etc/s6-overlay/
 
 RUN chmod +x /etc/cont-init.d/10-custom.sh
 
-ENV DNSMASQ_LISTENING all
-ENV PIHOLE_DNS_ 1.1.1.1;1.0.0.1
-ENV FONTFACE Terminus
-ENV FONTSIZE 8x14
-ENV WEBPASSWORD balena
-ENV VIRTUAL_HOST balena-devices.com
-
 ENV DBUS_SYSTEM_BUS_ADDRESS 'unix:path=/host/run/dbus/system_bus_socket'


### PR DESCRIPTION
This is especially useful to access the dashboard over tailnet.

Resolves: https://github.com/klutchell/balena-pihole/issues/208