### PR TITLE
Use official tailscale docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,6 @@ Advanced users can change the Unbound configuration by editing [`unbound.conf`](
 
 Included is a Tailscale service in order to [access your Pi-hole from anywhere](https://tailscale.com/kb/1114/pi-hole/).
 
-<https://github.com/klutchell/balena-tailscale>
-
 ## Help
 
 If you're having trouble getting the project running,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,21 +58,42 @@ services:
     environment:
       SET_HOSTNAME: pihole
 
+  # https://hub.docker.com/r/tailscale/tailscale
+  # https://github.com/tailscale/tailscale/blob/main/cmd/containerboot/main.go
+  # https://tailscale.com/kb/1282/docker
+  # https://tailscale.com/kb/1278/tailscaled
+  # https://tailscale.com/kb/1241/tailscale-up
+  # https://tailscale.com/kb/1242/tailscale-serve
+  # https://tailscale.com/kb/1311/tailscale-funnel
   tailscale:
-    build: tailscale
+    image: tailscale/tailscale:v1.54.1@sha256:ce594e3d18874960caa3f7d8fd8fc39a89b9c34e3ff05d6fdf3124cc550c8c2c
+    restart: unless-stopped
+    environment:
+      TS_STATE_DIR: /var/lib/tailscale
+      TS_SOCKET: /var/run/tailscale/tailscaled.sock
+      TS_USERSPACE: false
+      TS_AUTH_ONCE: false
+      TS_HOSTNAME: pi-hole
+      TS_EXTRA_ARGS: --accept-dns=false --reset
     network_mode: host
-    restart: on-failure
-    volumes:
-      - tailscale:/var/lib/tailscale
-    labels:
-      - io.balena.features.kernel-modules=1
     cap_add:
-      - net_admin
-      - net_raw
-      - sys_module
+      - NET_ADMIN
+      - NET_RAW
+      - SYS_MODULE
+    labels:
+      io.balena.features.kernel-modules: 1
     tmpfs:
       - /tmp
-      - /var/run/
-    environment:
-      TS_EXTRA_ARGS: --accept-dns=false --reset
-      REQUIRE_AUTH_KEY: "true"
+      - /run
+    volumes:
+      - tailscale:/var/lib/tailscale
+    entrypoint:
+      - /bin/sh
+      - -c
+    command:
+      - |
+        modprobe tun || true
+        modprobe wireguard || true
+        mkdir -p /dev/net
+        [ ! -c /dev/net/tun ] && mknod /dev/net/tun c 10 200
+        /usr/local/bin/containerboot

--- a/tailscale/Dockerfile.template
+++ b/tailscale/Dockerfile.template
@@ -1,3 +1,0 @@
-# https://github.com/klutchell/balena-tailscale/tags
-# hadolint ignore=DL3006
-FROM bh.cr/klutchell_blocks/tailscale-%%BALENA_ARCH%%/1.54.0


### PR DESCRIPTION
The balena wrapper wasn't adding any useful functionality and was slower to get updates.