### PR TITLE
Move some dnsmasq config to build time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: "2.1"
 
 volumes:
   pihole_config: {}
-  dnsmasq_config: {}
   tailscale: {}
 
 services:

--- a/pihole/Dockerfile
+++ b/pihole/Dockerfile
@@ -5,6 +5,16 @@ FROM pihole/pihole:2025.02.4@sha256:d83cd1ca243eace24c9d2f7320634eb47dee06dcdacb
 # hadolint ignore=DL3018
 RUN apk add --no-cache bash
 
+# Avoid port conflicts in 53 with the resin-dns interface
+# https://docs.pi-hole.net/ftldns/interfaces/
+RUN mkdir -p /etc/dnsmasq.d && \
+    echo "bind-interfaces" >/etc/dnsmasq.d/90-resin-dns.conf && \
+    echo "except-interface=resin-dns" >>/etc/dnsmasq.d/90-resin-dns.conf
+
+# enable inclusion of dnsmasq.d conf files
+# https://github.com/pi-hole/FTL/pull/1734
+ENV FTLCONF_misc_etc_dnsmasq_d='true'
+
 COPY balena-init.sh /
 
 RUN chmod +x /balena-init.sh
@@ -18,7 +28,3 @@ ENV FTLCONF_dns_upstreams='1.1.1.1;1.0.0.1'
 ENV FTLCONF_webserver_api_password='balena'
 # https://github.com/pi-hole/FTL/blob/ac500d5f1ff192d087209d6e9b955515c8f35434/test/pihole.toml#L627-L660
 # ENV FTLCONF_webserver_port='80o,443os,[::]:80o,[::]:443os'
-
-# enable inclusion of dnsmasq.d conf files
-# https://github.com/pi-hole/FTL/pull/1734
-ENV FTLCONF_misc_etc_dnsmasq_d='true'

--- a/pihole/balena-init.sh
+++ b/pihole/balena-init.sh
@@ -2,14 +2,6 @@
 
 set -e
 
-# avoid port conflicts with resin-dns
-# https://docs.pi-hole.net/ftldns/interfaces/
-mkdir -p /etc/dnsmasq.d
-echo "bind-interfaces" >/etc/dnsmasq.d/90-resin-dns.conf
-echo "except-interface=resin-dns" >>/etc/dnsmasq.d/90-resin-dns.conf
-# remove deprecated dnsmasq config files if they exist
-rm -f /etc/dnsmasq.d/balena.conf /etc/dnsmasq.d/01-pihole.conf
-
 # Use EDNS_PACKET_MAX=1232 to avoid unbound DNS packet size warnings
 # https://docs.pi-hole.net/guides/dns/unbound/
 # https://docs.pi-hole.net/ftldns/dnsmasq_warn/#reducing-dns-packet-size-for-nameserver-address-to-safe_pktsz


### PR DESCRIPTION
As of pihole v6 we are no longer persisting
dnsmasq	 config volumes, so we can set these persistent config settings at build time.