### PR TITLE
Sleep in a loop if setfont cannot be applied to tty1

### DIFF
--- a/padd/entrypoint.sh
+++ b/padd/entrypoint.sh
@@ -5,10 +5,10 @@ set -e
 console=/dev/tty1
 
 on_error() {
-   echo "Exited with code ${?}, sleeping for a few seconds..."
-   # Sleep for random amount of time between 5 and 20 seconds
+   echo "Exited with code ${?}, sleeping for 30 to 90 seconds..."
+   # Sleep for random amount of time between 30 and 90 seconds
    # before restarting and trying again...
-   sleep $((RANDOM % 15 + 5))
+   sleep $((RANDOM % 60 + 30))
 }
 
 # Trap all errors that are not container stop signals
@@ -34,6 +34,11 @@ dbus-send \
    /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.StartUnit \
    string:"plymouth-quit.service" string:"replace"
 
+while ! setfont -C /dev/tty1; do
+   echo "Failed to set console font, this is expected on a headless system"
+   echo "Sleeping for 5 to 15 minutes before retrying..."
+   sleep $((RANDOM % 600 + 300))
+done
 
 # https://wiki.alpinelinux.org/wiki/Fonts
 # https://www.man7.org/linux/man-pages/man8/setfont.8.html


### PR DESCRIPTION
This is expected on headless systems, specifically RPi4 which returns an error when setfont is used without an attached screen.

Fixes: https://github.com/klutchell/balena-pihole/issues/369