### PR TITLE
Fix hostname service deadlock

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,11 +56,11 @@ services:
     image: bh.cr/balenalabs/fbcp/1.0.4
     privileged: true
 
-  # https://github.com/balenablocks/hostname
-  # https://hub.balena.io/blocks/1918776/hostname-rpi
+  # One-shot service that sets the device hostname via the supervisor API.
+  # Replaces bh.cr/g_tomas_migone1/hostname-rpi, which contends with the supervisor's own apply loop.
   hostname:
-    image: bh.cr/g_tomas_migone1/hostname-rpi/0.2.1
-    restart: no
+    build: hostname
+    restart: "no"
     labels:
       io.balena.features.supervisor-api: 1
     environment:

--- a/hostname/Dockerfile
+++ b/hostname/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.24.1
+
+# hadolint ignore=DL3018
+RUN apk add --no-cache curl jq
+
+COPY entrypoint.sh /usr/src/entrypoint.sh
+RUN chmod +x /usr/src/entrypoint.sh
+
+CMD ["/usr/src/entrypoint.sh"]

--- a/hostname/entrypoint.sh
+++ b/hostname/entrypoint.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -u
+
+echo "--- Hostname ---"
+
+if [ -z "${SET_HOSTNAME:-}" ]; then
+    echo "SET_HOSTNAME not set, nothing to do."
+    exit 0
+fi
+
+API="${BALENA_SUPERVISOR_ADDRESS}/v1/device/host-config"
+AUTH="Authorization: Bearer ${BALENA_SUPERVISOR_API_KEY}"
+CURL="curl -s --connect-timeout 10 --max-time 30"
+
+CURRENT="$(${CURL} -f -H "${AUTH}" "${API}" | jq -r '.network.hostname // empty')"
+if [ -z "${CURRENT}" ]; then
+    echo "Warning: could not read current hostname from the supervisor."
+fi
+echo "Current hostname: ${CURRENT}"
+echo "Target hostname:  ${SET_HOSTNAME}"
+
+if [ "${CURRENT}" = "${SET_HOSTNAME}" ]; then
+    echo "Hostname already set, nothing to do."
+    exit 0
+fi
+
+# The supervisor serializes host-config changes against its own apply loop and
+# returns 423 while one is in flight, so retry until it clears.
++BODY="$(jq -n --arg h "${SET_HOSTNAME}" '{network:{hostname:$h},force:true}')"
+for attempt in 1 2 3 4 5; do
+    echo "Setting hostname (attempt ${attempt})..."
+    HTTP_CODE="$(${CURL} -s -o /tmp/response -w '%{http_code}' -X PATCH "${API}" \
+        -H "${AUTH}" \
+        -H 'Content-Type: application/json' \
+        -d "${BODY}")"
+    if [ "${HTTP_CODE}" = "200" ]; then
+        echo "Hostname updated, services will restart to pick it up."
+        exit 0
+    fi
+    echo "Supervisor returned HTTP ${HTTP_CODE}: $(cat /tmp/response)"
+    sleep 10
+done
+
+echo "Failed to set hostname after 5 attempts."
+exit 1

--- a/hostname/entrypoint.sh
+++ b/hostname/entrypoint.sh
@@ -12,7 +12,7 @@ API="${BALENA_SUPERVISOR_ADDRESS}/v1/device/host-config"
 AUTH="Authorization: Bearer ${BALENA_SUPERVISOR_API_KEY}"
 CURL="curl -s --connect-timeout 10 --max-time 30"
 
-CURRENT="$(${CURL} -H "${AUTH}" "${API}" | jq -r '.network.hostname // empty')"
+CURRENT="$(${CURL} -f -H "${AUTH}" "${API}" | jq -r '.network.hostname // empty')"
 if [ -z "${CURRENT}" ]; then
     echo "Warning: could not read current hostname from the supervisor."
 fi

--- a/hostname/entrypoint.sh
+++ b/hostname/entrypoint.sh
@@ -29,7 +29,7 @@ fi
 BODY="$(jq -n --arg h "${SET_HOSTNAME}" '{network:{hostname:$h},force:true}')"
 for attempt in 1 2 3 4 5; do
     echo "Setting hostname (attempt ${attempt})..."
-    HTTP_CODE="$(${CURL} -s -o /tmp/response -w '%{http_code}' -X PATCH "${API}" \
+    HTTP_CODE="$(${CURL} -f -o /tmp/response -w '%{http_code}' -X PATCH "${API}" \
         -H "${AUTH}" \
         -H 'Content-Type: application/json' \
         -d "${BODY}")"

--- a/hostname/entrypoint.sh
+++ b/hostname/entrypoint.sh
@@ -12,7 +12,7 @@ API="${BALENA_SUPERVISOR_ADDRESS}/v1/device/host-config"
 AUTH="Authorization: Bearer ${BALENA_SUPERVISOR_API_KEY}"
 CURL="curl -s --connect-timeout 10 --max-time 30"
 
-CURRENT="$(${CURL} -f -H "${AUTH}" "${API}" | jq -r '.network.hostname // empty')"
+CURRENT="$(${CURL} -H "${AUTH}" "${API}" | jq -r '.network.hostname // empty')"
 if [ -z "${CURRENT}" ]; then
     echo "Warning: could not read current hostname from the supervisor."
 fi
@@ -26,7 +26,7 @@ fi
 
 # The supervisor serializes host-config changes against its own apply loop and
 # returns 423 while one is in flight, so retry until it clears.
-+BODY="$(jq -n --arg h "${SET_HOSTNAME}" '{network:{hostname:$h},force:true}')"
+BODY="$(jq -n --arg h "${SET_HOSTNAME}" '{network:{hostname:$h},force:true}')"
 for attempt in 1 2 3 4 5; do
     echo "Setting hostname (attempt ${attempt})..."
     HTTP_CODE="$(${CURL} -s -o /tmp/response -w '%{http_code}' -X PATCH "${API}" \


### PR DESCRIPTION
Fixes #433 

## Description

Replace the external hostname block (`bh.cr/g_tomas_migone1/hostname-rpi`) with a small in-repo service (`hostname/`, Alpine + curl + jq, ~15 MB):

- Reads the current hostname first and exits 0 when it already matches `SET_HOSTNAME`.
- Retries 5× with backoff on transient supervisor 423s, exits non-zero on real failure.
- Uses `Authorization: Bearer` header instead of query-string API key.
- `restart: "no"` — runs once per deploy.

`SET_HOSTNAME` keeps its compose default (`pihole`) and can be overridden by a fleet variable. Changing the variable re-runs the one-shot, so devices can be renamed after deployment without pushing a new release.

## Testing

On a Raspberry Pi 4 (raspberrypi4-64), balenaOS 7.4.0+rev1, **supervisor v19.0.0**:

- No restart churn, hostname applies cleanly.
- Full post-deploy round-trip rename (`pihole` → `pihole2` → `pihole` via device variable) confirmed working through mDNS resolution.